### PR TITLE
allow specifying document name (title) and description

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 module.exports = function tokml(geojson, options) {
 
     options = options || {
+        documentName: undefined,
+        documentDescription: undefined,
         name: 'name',
         description: 'description',
     };
@@ -8,6 +10,8 @@ module.exports = function tokml(geojson, options) {
     return '<?xml version="1.0" encoding="UTF-8"?>' +
         tag('kml',
             tag('Document',
+                documentName(options) +
+                documentDescription(options) +
                 root(geojson, options)
                ), [['xmlns', 'http://www.opengis.net/kml/2.2']]);
 };
@@ -37,6 +41,14 @@ function root(_, options) {
             }
     }
     return '';
+}
+
+function documentName(options) {
+    return (options.documentName !== undefined) ? tag('name', options.documentName) : '';
+}
+
+function documentDescription(options) {
+    return (options.documentDescription !== undefined) ? tag('description', options.documentDescription) : '';
 }
 
 function name(_, options) {

--- a/test/data/document_name_desc.geojson
+++ b/test/data/document_name_desc.geojson
@@ -1,0 +1,3 @@
+{ "type": "FeatureCollection",
+  "features": []
+}

--- a/test/data/document_name_desc.kml
+++ b/test/data/document_name_desc.kml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><kml xmlns="http://www.opengis.net/kml/2.2"><Document><name>Document Title</name><description>Document Description</description></Document></kml>

--- a/test/kml.test.js
+++ b/test/kml.test.js
@@ -64,6 +64,12 @@ describe('tokml', function() {
         it('name and description', function() {
             expect(tokml(file('name_desc.geojson'))).to.eql(output('name_desc.kml'));
         });
+        it('document name & description', function() {
+            expect(tokml(file('document_name_desc.geojson'), {
+                documentName: 'Document Title',
+                documentDescription: 'Document Description',
+            })).to.eql(output('document_name_desc.kml'));
+        });
     });
 });
 


### PR DESCRIPTION
Adds two new options: `documentName` and `documentDescription`, that set the appropriate tags of the root document. This is useful for providing meaningful titles and descriptions for applications like google-earth.

The PR includes unit tests. Coverage is still at 4x100% ;)

```
Statements   : 100% ( 58/58 )
Branches     : 100% ( 23/23 )
Functions    : 100% ( 29/29 )
Lines        : 100% ( 55/55 )
```
