### PR TITLE
add missing dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: tokml.js site/site.js
 
-tokml.js:
+tokml.js: index.js
 	browserify -s tokml index.js > tokml.js
 
 site/site.js: site/index.js


### PR DESCRIPTION
I guess this caused [tokml.js](https://github.com/mapbox/tokml/blob/gh-pages/tokml.js) to be a little bit out of date.
